### PR TITLE
Revert delete smarts295.out.txt files

### DIFF
--- a/pySMARTS/main.py
+++ b/pySMARTS/main.py
@@ -2445,14 +2445,14 @@ def _smartsAll(CMNT, ISPR, SPR, ALTIT, HEIGHT, LATIT, IATMOS, ATMOS, RH, TAIR, S
         os.remove('smarts295.inp.txt')
     except:
         pass
-    #try:
-    #    os.remove('smarts295.out.txt')
-    #except:
-    #    pass  
-    #try:       
-    #    os.remove('smarts295.ext.txt')
-    #except:
-    #    pass
+    try:
+        os.remove('smarts295.out.txt')
+    except:
+        pass  
+    try:       
+        os.remove('smarts295.ext.txt')
+    except:
+        pass
     try:
         os.remove('smarts295.scn.txt')
     except:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,7 +41,7 @@ def test_SpectraZenAzm():
     material = 'LiteSoil'
     min_wavelength = 300
     max_wavelength = 4000
-    smarts_res = pySMARTS.SMARTSSpectraZenAzm('2 3 4', str(zen), str(azm),
+    smarts_res = pySMARTS.SMARTSSpectraZenAzm(IOUT='2 3 4', ZENITH=str(zen), AZIM=str(azm),
                                      material=material,
                                      min_wvl=str(min_wavelength),
                                      max_wvl=str(max_wavelength))


### PR DESCRIPTION
sometime after v0.0.1 we took out the action that deleted the file `smarts295.out.txt` prior to running SMARTS.  Unfortunately the FORTRAN code won't over-write this file if it already exists - it'll just error out.  Output.txt messages were returning the following:

**********************************
Welcome to SMARTS, version 2.9.5!              
**********************************
File specified STATUS= "NEW" already exists (see "Input/Output" in the Lahey
 Fortran 90 Language Reference), FILE=smarts295.out.txt, UNIT=16.

Program completed
Press Enter to Continue.

